### PR TITLE
fix: ensure visibility of 'data.LanguageId' element before interaction

### DIFF
--- a/src/main/java/com/xjudge/service/scraping/atcoder/AtCoderSubmission.java
+++ b/src/main/java/com/xjudge/service/scraping/atcoder/AtCoderSubmission.java
@@ -101,7 +101,6 @@ public class AtCoderSubmission implements SubmissionAutomation {
     private void submitHelper(SubmissionInfoModel data){
         try {
             Select taskNameSelect = new Select(driver.findElement(By.name("data.TaskScreenName")));
-            Select languageIdSelect = new Select(driver.findElement(By.name("data.LanguageId")));
             WebElement toggleButton = driver.findElement(By.cssSelector("button.btn-toggle-editor"));
             WebElement sourceCodeArea = driver.findElement(By.name("sourceCode"));
             WebElement submitButton = driver.findElement(By.id("submit"));
@@ -111,6 +110,8 @@ public class AtCoderSubmission implements SubmissionAutomation {
             }
 
             taskNameSelect.selectByValue(data.problemCode());
+            WebElement languageIdElement = wait.until(ExpectedConditions.visibilityOfElementLocated(By.name("data.LanguageId")));
+            Select languageIdSelect = new Select(languageIdElement);
             languageIdSelect.selectByValue(data.compiler().getIdValue());
             sourceCodeArea.sendKeys(data.solutionCode());
             submitButton.submit();


### PR DESCRIPTION
- Modify the 'submitHelper' method in 'AtCoderSubmission.java' to wait until the 'data.LanguageId' element is visible before interacting with it. This change resolves the 'Element is not currently visible and may not be manipulated' error encountered when using Selenium WebDriver.